### PR TITLE
Update LoadLayout.vue

### DIFF
--- a/src/layouts/LoadLayout.vue
+++ b/src/layouts/LoadLayout.vue
@@ -10,3 +10,11 @@ export default {
   name: 'LoadLayout'
 }
 </script>
+
+<style lang="stylus">
+.loading-layout
+  height 100vh
+  display flex
+  align-items center
+  justify-content center
+</style>

--- a/src/layouts/LoadLayout.vue
+++ b/src/layouts/LoadLayout.vue
@@ -13,7 +13,7 @@ export default {
 
 <style lang="stylus">
 .loading-layout
-  height 100vh
+  min-height 100vh
   display flex
   align-items center
   justify-content center


### PR DESCRIPTION
Make the Loading page fit 100% of the viewport and make the loading component appear horizontally and vertically centered.
This removes the white padding at the bottom of the page while the Loading component appears.