### PR TITLE
Cambio de url http://media.blizzard.com a https://blzmedia-a.akamaihd…

### DIFF
--- a/src/views/Hero/HeroItems/ItemDetail.vue
+++ b/src/views/Hero/HeroItems/ItemDetail.vue
@@ -48,7 +48,11 @@ export default {
   },
   computed: {
     itemUrl () {
-      const host = 'http://media.blizzard.com/d3/icons/items/large/'
+      // const baseUrl = 'http://media.blizzard.com/'
+      // La nueva url tiene certificado SSL (https),
+      // así que el navegador las muestra sin problemas en producción.
+      const baseUrl = 'https://blzmedia-a.akamaihd.net/'
+      const host = `${baseUrl}d3/icons/items/large/`
       return `${host}${this.item.icon}.png`
     },
     itemHasGems () {


### PR DESCRIPTION
….net

Permite ver las imágenes en producción y no tener conflictos http con https.

Tomé la url inspeccionando la pagina oficial de items: Por ejemplo el item:
https://eu.diablo3.blizzard.com/en-us/item/leorics-crown-Unique_Helm_002_p1