### PR TITLE
Cambio de url http://media.blizzard.com a https://blzmedia-a.akamaihd…

### DIFF
--- a/src/views/Hero/HeroItems/ItemDetailGem.vue
+++ b/src/views/Hero/HeroItems/ItemDetailGem.vue
@@ -13,7 +13,12 @@ export default {
   },
   computed: {
     gemUrl () {
-      const host = 'http://media.blizzard.com/d3/icons/items/small/'
+      // Cambio de 'large' por 'small'
+      // const baseUrl = 'http://media.blizzard.com/'
+      // La nueva url tiene certificado SSL (https),
+      // así que el navegador las muestra sin problemas en producción.
+      const baseUrl = 'https://blzmedia-a.akamaihd.net/'
+      const host = `${baseUrl}d3/icons/items/small/`
       return `${host}${this.gem.item.icon}.png`
     },
     gemTitle () {


### PR DESCRIPTION
….net

Permite ver las imágenes en producción y no tener conflictos http con https.

Tomé la url inspeccionando la pagina oficial de items: Por ejemplo el item:
https://eu.diablo3.blizzard.com/en-us/item/leorics-crown-Unique_Helm_002_p1