### PR TITLE
[ActiveSkill] Cambio de url http://media.blizzard.com a https://blzme…

### DIFF
--- a/src/views/Hero/HeroSkills/ActiveSkill.vue
+++ b/src/views/Hero/HeroSkills/ActiveSkill.vue
@@ -37,7 +37,11 @@ export default {
   computed: {
     skillUrl () {
       const sizes = [21, 42, 64]
-      const host = `http://media.blizzard.com/d3/icons/skills/${sizes[1]}/`
+      // const baseUrl = 'http://media.blizzard.com/'
+      // La nueva url tiene certificado SSL (https),
+      // así que el navegador las muestra sin problemas en producción.
+      const baseUrl = 'https://blzmedia-a.akamaihd.net/'
+      const host = `${baseUrl}d3/icons/skills/${sizes[1]}/`
       return `${host}${this.skill.icon}.png`
     },
     slotClass () {


### PR DESCRIPTION
…dia-a.akamaihd.net

Permite ver las imágenes en producción y no tener conflictos http con https.

Tomé la url inspeccionando la pagina oficial de items: Por ejemplo el item:
https://eu.diablo3.blizzard.com/en-us/item/leorics-crown-Unique_Helm_002_p1